### PR TITLE
Restored old PCRE example with modification

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ $ export LD_LIBRARY_PATH=/usr/lib64:${LD_LIBRARY_PATH}
 
 #### MacOS
 
-For MacOS, if user machine is version<=10.13, `libffi` should be in `/usr/lib` and no action is required. You can proceed to the [next step](#Building ffikdb).
+For MacOS, if user machine is version<=10.13, `libffi` should be in `/usr/lib` and no action is required. You can proceed to the [next step](#Buildingffikdb).
 
 If user machine is version>=10.14 `libffi` needs to be installed via `brew` command:
 

--- a/examples/pcre.q
+++ b/examples/pcre.q
@@ -56,7 +56,7 @@
 
 // @brief Compile regex.
 // @param pattern {string}: Regex pattern.
-// @param cflags {int}: Bit field of compile flags.
+// @param cflags {list of bool}: Bit field of compile flags.
 // @return {list of byte}: Regex object.
 .pcre.regcomp:{[pattern;cflags]
   regex:64#0x0;

--- a/examples/pcre.q
+++ b/examples/pcre.q
@@ -1,0 +1,160 @@
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++//
+//                            File Description                          //
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++//
+
+/
+* @file pcre.q
+* @overview
+* This file shows how to use ffi interface to utilize functions in PCRE library.
+* @note
+* Reference: https://linux.die.net/man/3/pcreposix
+\
+
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++//
+//                            Load Libraries                            //
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++//
+
+\l ffi.q
+
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++//
+//                            Global Variable                           //
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++//
+
+// regcomp cflags
+.pcre.REG_BASIC:   0000b;
+.pcre.REG_EXTENDED:0001b;
+.pcre.REG_ICASE:   0010b;
+.pcre.REG_NEWLINE: 0100b;
+.pcre.REG_NOSUB:   1000b;
+// regexec eflags
+.pcre.REG_NOTBOL:  0001b;
+.pcre.REG_NOTEOL:  0010b;
+.pcre.REG_STARTEND:0100b;
+
+// size of 
+.pcre.regoff_t:$["m"=.ffi.os[]; 0; 0i];
+
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++//
+//                            Load Functions                            //
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++//
+
+// int regcomp(regex_t *preg, const char *pattern,int cflags);
+.pcre.regcomp_impl:.ffi.bind[`regcomp;"Xsi";"i"];
+
+// int regexec(regex_t *preg, const char *string,size_t nmatch, regmatch_t pmatch[], int eflags);
+.pcre.regexec_impl:.ffi.bind[`regexec;"XCjIi";"i"];
+
+// size_t regerror(int errcode, const regex_t *preg,char *errbuf, size_t errbuf_size);
+.pcre.regerror_impl:.ffi.bind[`regerror;"iXCj";"j"];
+
+// void regfree(regex_t *preg);
+.pcre.regfree_impl:.ffi.bind[`regfree;"X";" "];
+
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++//
+//                            Wrapper Functions                         //
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++//
+
+// @brief Compile regex.
+// @param pattern {string}: Regex pattern.
+// @param cflags {int}: Bit field of compile flags.
+// @return {list of byte}: Regex object.
+.pcre.regcomp:{[pattern;cflags]
+  regex:64#0x0;
+  cflags:2 sv $[1h ~ type cflags; cflags; (|/) cflags];
+  error:.pcre.regcomp_impl (regex; `$pattern; cflags; ::);
+  $[null error; regex; '.pcre.regerror[regex; error]]
+ };
+
+// @brief Execute regex.
+// @param regex {list of byte}: Regex object.
+// @param text {string}: Text to match the regex pattern.
+// @return
+// - bool
+.pcre.regexec:{[regex; text] null .pcre.regexec_impl (regex; text; 0; 0#0i; 0i; ::)};
+
+// @brief Decode regex error code to readable error message.
+// @param regex {list of byte}: Regex object.
+// @error_code {int}: Error code.
+// @return
+// - string: Error message for the error code.
+.pcre.regerror:{[regex;error_code]
+  buffer:100#"";
+  length:.pcre.regerror_impl (error_code; regex; buffer; count buffer; ::);
+  (length-1)#buffer
+ };
+
+// @brief Free regex.
+.pcre.regfree:{[regex]
+  .pcre.regfree_impl (regex; ::)
+ };
+
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++//
+//                             Play Around                              //
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++//
+
+//%% Simple Pattern %%//vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv/
+
+// https://eli.thegreenplace.net/2012/11/14/some-notes-on-posix-regular-expressions
+
+// basic //---------------------------/
+
+// Compile regex
+regex:.pcre.regcomp[pattern:"[a-z][a-z]*[0-9]\\{2,3\\}"; .pcre.REG_BASIC];
+if[.pcre.regexec[regex; s:"abc123"]; show " " sv (pattern; "matches(basic)"; s)];
+
+// Free regex
+.pcre.regfree regex;
+
+// extended //------------------------/
+
+// Compile regex
+regex:.pcre.regcomp[pattern:"[a-z]+[0-9]{2,3}"; .pcre.REG_EXTENDED];
+if[.pcre.regexec[regex;s:"abc123"];show " " sv (pattern; "matches(extended)";s)];
+
+// Free regex
+.pcre.regfree regex;
+
+// pmatch //--------------------------/
+
+// compile regex
+regex:.pcre.regcomp["(.*)(hello)+"; .pcre.REG_EXTENDED];
+
+texts:("This should match... hello"; "This could match... hello!"; "More than one hello.. hello"; "No chance of a match...");
+matches:.pcre.regexec[regex;] each texts;
+show matches;
+
+pmatch:(2*pcount:4)#.pcre.regoff_t;
+.pcre.regexec_impl (regex; `$"123hello"; pcount; pmatch; 0i; ::)
+
+// Free regex
+.pcre.regfree regex;
+
+//%% Email Address %%//vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv/
+
+// Compile regex
+regex:.pcre.regcomp["From:([^@]+)@([^\r]+)"; (.pcre.REG_EXTENDED; .pcre.REG_NEWLINE)];
+multiline:"From:regular.expressions@example.com\r\nFrom:exddd@43434.com\r\nFrom:7853456@exgem.com\r\n";
+emailmatch:.pcre.regexec[regex;`$multiline]
+
+// Free regex
+.pcre.regfree regex;
+
+//%% Back Reference %%//vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv/
+
+// Compile regex
+regex:.pcre.regcomp[pattern:"([a-z]+)_\\1";.pcre.REG_EXTENDED];
+pmatch:(2*pcount:2)#.pcre.regoff_t;
+if[null .pcre.regexec_impl (regex; s:"abc_abc"; pcount; pmatch;0i; ::); show " " sv (pattern; "matches(extended)"; s; "with groups "), sublist[;s]@/:2 cut pmatch];
+
+// Free regex
+.pcre.regfree regex;
+
+//%% Compile tracking %%//vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv/
+
+// Compile regex
+regex:.pcre.regcomp[rx:"^(A+)*B";.pcre.REG_EXTENDED];
+\ts .pcre.regexec[regex; s:(1000#"A"),"C"]
+
+// Free regex
+.pcre.regfree regex;
+

--- a/q/ffi.q
+++ b/q/ffi.q
@@ -15,21 +15,67 @@
 
 //%% Main Interface %%//vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv/
 
+// @brief Creates a projection with the function resolved to call with arguments.
+// @param funcname {dynamic}: Name of function.
+// - symbol: Name of function to look for.
+// - symbol list: list of shared object and a function name in the library.
+// @param argtypes {string}: type characters of arguments.
+// @param returntype {char}: type character of returned value
+// @return
+// - function
 .ffi.bind:`ffikdb 2: (`bind; 3);
+
+// @brief A simple function call, intended for one-off calls.
+// @param returntype_and_func {dynaic}:
+// - symbol: Name of function
+// - tuple of (q type character of returned value; symbol function name or list of shared object name and function name)
+// @param args {compound list}: List of arguments to be passed to the foreign function. This list must have (::) at the end.
+// @return 
+// - any
 .ffi.callFunction:`ffikdb 2: (`call_function; 2);
+
+// @brief Load all symbols in a given shared object to current process. Once eintire library
+//  is loaded, shared library name does not need to be passed as an argument of `bind` and `callFunction`.
+// @param shared_object {symbol}: Name of a shared library.
+// @note
+// This is an experimental feature.
+.ffi.loadlib:`ffikdb 2: (`loadlib; 1);
 
 //%% Utility %%//vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv/
 
+// @brief Search a variable with a given name and convert it to K object.
+// @param rtype_and_var {dynamic}:
+// - symbol: Variable name
+// - tuple of (char; symbol): (type character of returned value; variable name or list of shared object name and variable name)
+// @return 
+// - any
 .ffi.cvar:`ffikdb 2: (`cvar; 1);
+
+// @brief Set a given number on `errno` and returns old `errno` value. If the argument is null or non-int
+// value it returns current `errno` value. 
+// @param n {int}: New `errno` value. This value must be int.
+// @return 
+// - int: Old `errno` value.
 .ffi.setErrno:`ffikdb 2: (`set_errno; 1);
 
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++//
 //                           Other Utilities                            //
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++//
 
+// @brief Return an extension of a shared library according to a kind of OS.
+// @return
+// - symbol: File extension.
 .ffi.extension:{[] ("wlm"!`dll`so`dylib) first string .z.o};
+
+// @brief Get a size of void pointer.
+// @return
+// - int: Size of a void pointer.
 .ffi.ptrsize:{$[.z.o like "?32"; 4i; 8i]};
-.ffi.os:{first string .z.o};
+
+// @brief Get the first symbol of OS type.
+// @return 
+// - char: The first symbol of OS type.
+.ffi.os:{[] first string .z.o};
 
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++//
 //                 Load for internal Reason (DO NOT CALL)               //

--- a/src/ffi.c
+++ b/src/ffi.c
@@ -862,10 +862,11 @@ EXP K bind_K_function(K funcname, K n) {
 //%% Probably Garbage %%//vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv/
 
 /**
- * @brief Load all symbols in a given shared object to current process.
+ * @brief Load all symbols in a given shared object to current process. Once eintire library
+ *  is loaded, shared library name does not need to be passed as an argument of `bind` and `callFunction`.
  * @param library: Name of shared object.
  * @note
- * Not documented anywhere. Probably garbage.
+ * Not documented anywhere. Can be restored as an experimental feature.
  */
 EXP K loadlib(K library) {
   void *handle;


### PR DESCRIPTION
- Restored `pcre.q` to examples/ after modifying it.
- Added `loadlib` as an experimental feature.
- Added `document` to ffi.q