### PR TITLE
Fixed file description of examples.

### DIFF
--- a/examples/c_api.q
+++ b/examples/c_api.q
@@ -3,8 +3,7 @@
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++//
 
 /
-* @file
-* c_api.q
+* @file c_api.q
 * @overview
 * This file shows how to use ffi interface to utilize functions in C API for q.
 *  This example alone does not make an example. You need to launch another q process connecting

--- a/examples/rmath.q
+++ b/examples/rmath.q
@@ -3,8 +3,7 @@
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++//
 
 /
-* @file
-* rmath.q
+* @file rmath.q
 * @overview
 * This file shows how to use ffi interface to utilize functions in Rmath library.
 \

--- a/examples/stdlib.q
+++ b/examples/stdlib.q
@@ -3,8 +3,7 @@
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++//
 
 /
-* @file
-* stdlib.q
+* @file stdlib.q
 * @overview
 * This file shows how to use ffi interface to utilize functions in C standard library
 \

--- a/src/ffi.c
+++ b/src/ffi.c
@@ -903,19 +903,20 @@ EXP K set_errno(K n) {
 }
 
 /**
- * @brief Derefer ffi structs as K objects. Start index is given by `kidx` and the number of objects to be
+ * @brief Derefer ffi pointer as K objects. Start index is given by `kidx` and the number of objects to be
  *  dereferred is given by a length of returntypes which denote return q types of the dereferred results.
- * @param x: UNKNOWN
+ * @param x: Raw pointer.
  * @param returntypes: Characters denoting q types of returned values.
  * @param kidx: Index to start to read struct.
  * @note
- * This is not documented anywhere. Probably garbage.
+ * This is not documented anywhere. Probably garbage. There is no way to get a raw pointer from q in the
+ *  first place.
  */ 
 EXP K deref(K x, K returntypes, K kidx) {
   
   G *p;
 
-  if((!((x->t == KJ && sizeof(void *) == 8) || (x->t == KI && sizeof(void *) == 4))) || returntypes->t != KC || kidx->t != -KJ) {
+  if((!((x->t == -KJ && sizeof(void *) == 8) || (x->t == -KI && sizeof(void *) == 4))) || returntypes->t != KC || kidx->t != -KJ) {
     // type and bitness does not match or return type is not string or index is not long
     return krr("type: [r;C;j] expected"); 
   }


### PR DESCRIPTION
- Changed file description of examples.
- Fixed type check of `deref` function (garbage function)