### PR TITLE
Fixed C API example and added document

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,89 @@
+---
+title: Interface example | FFI | Interfaces | Documentation for kdb+ and q
+keywords: ffi, api, fusion, interface, library, q
+hero: <i class="fab fa-superpowers"></i> Fusion for Kdb+
+---
+
+# FFI interface example
+
+## Rmath library
+
+Bindings to [Rmath](https://cran.r-project.org/doc/manuals/r-release/R-admin.html#The-standalone-Rmath-library) using FFI for kdb+.
+
+`Rmath` provides the routines supporting the distribution and special (e.g. Bessel, beta and gamma functions) functions in `R`. 
+
+This example requires the stand-alone Rmath library to be installed as well as FFI for kdb+. Install Rmath according to the platform you are using. For example;
+
+- Ubuntu:
+
+```bash
+
+$ sudo apt-get install r-mathlib
+
+```
+
+- CentOS/RedHat:
+ 
+```bash
+
+$ sudo yum install libRmath
+
+```
+
+Generate 100K numbers from normal distribution:
+
+```q
+
+q)// Bind rnorm function
+q).rm.rnorm:.ffi.bind[`libRmath.so`rnorm; "jff"; "f"]
+q)// Bind set_seed function
+q).rm.set_seed:.ffi.bind[`libRmath.so`set_seed; "ii"; " "]
+q)// Set random seed
+q).rm.set_seed (456i; 789i; ::)
+q)norms:`float$()
+q)do[100000; gen:.rm.rnorm (1; 0f; 1f; ::); if[-9h ~ type gen; norms,: gen]]
+q)// verify that avg and dev are 0 and 1
+q)(avg; dev) @\: norms
+0.003488721 1.002219
+
+```
+
+## Standard C Library
+
+```q
+
+q)// Buffer
+q)buffer: 80#"\000"
+q)// Write to buffer and return the number of bytes which was written
+q)n:.ffi.callFunction[("i"; `sprintf)] (buffer; "%s %.4f %hd\000"; "example\000"; 3.16f; 144000h; ::)
+q)// Show the written charcters
+q)buffer til n
+"example 3.1600 32767"
+q)// Bind qsort function
+q).cstdlib.qsort:.ffi.bind[`qsort; "liik"; " "];
+q)// Callback function
+q)cmp:{0N!"compare: ",.Q.s x,y; (x>y)-x<y};
+q)seq:3 1 2i
+q).cstdlib.qsort (seq; `int$count seq; 4i; (cmp; "II"; "i"); ::)
+"compare: 1 2i\n"
+"compare: 3 1i\n"
+"compare: 3 2i\n"
+q)seq
+1 2 3i
+q)seq:101b
+q).cstdlib.qsort (seq; `int$count seq; 1i; (cmp; "BB"; "i"); ::)
+"compare: 01b\n"
+"compare: 10b\n"
+"compare: 11b\n"
+q)seq
+011b
+q)seq:`c`a`b;
+q)// symbols are pointers - size of pointer is .ffi.ptrsize[]
+q).cstdlib.qsort (seq; `int$count seq; .ffi.ptrsize[]; (cmp; "SS"; "i"); ::)
+"compare: `a`b\n"
+"compare: `c`a\n"
+"compare: `c`b\n"
+q)seq
+`a`b`c
+
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,26 @@
+---
+title: Using foreign functions with kdb+ – Interfaces – kdb+ and q documentation
+description: FFI for kdb+ is an extension to kdb+ for loading and calling dynamic libraries using pure q.
+hero: <i class="fab fa-superpowers"></i> Fusion for Kdb+
+keywords: foreign, function, fusion, interface, kdb+, q
+---
+
+# ffikdb
+
+FFI (foreign function interface) is a mechanism by which a program written in one programming language can call routines or make use of services written in another. Some programs may not know at the time of compilation what arguments are to be passed to a function. For instance, an interpreter may be told at run-time about the number and types of arguments used to call a given function. Libffi can be used in such programs to provide a bridge from the interpreter program to compiled code.
+
+This interface is utilizing [libffi](https://sourceware.org/libffi/) which can be already installed in your OS except for some Linux OS (See pre-requisite in :fontawesome-brands-github: [KxSystems/ffikdb](https://github.com/KxSystems/ffi#requirements)). The documentation of libffi API can be found in its [repository](https://github.com/libffi/libffi/tree/master/doc).
+
+## FFI/kdb+ Integration
+
+ffikdb is an extension to kdb+ for loading and calling dynamic libraries using pure q. The main purpose of the library is to build stable interfaces on top of external libraries, or to interact with the operating system from `q`. No compiler toolchain or writing C/C++ code is required to use this library.
+
+!!! warning "Know what you are doing"
+
+    You don't need to write C code, but you do need to know what you are doing. You can easily crash the kdb+ process or corrupt in-memory data structures with no hope of finding out what happened. For example, when q callback function is passed to foreign function and the q function failed, user might be able to see error message in console but as the foreign function cannot handle q error, the execution crashes and leads to entire application crash. Or if user passed valid but wrong tye characters to q callback, interna conversion failure of q cannot be handed and application crashes without any error message.
+
+    No support is offered for crashes caused by use of this library.
+
+### Acknowledgement
+
+We are grateful to Alexander Belopolsky for allowing us to adapt and expand on his original codebase. 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,181 @@
+---
+title: Function reference | FFI | Interfaces | Documentation for kdb+ and q
+keywords: ffi, api, fusion, interface, q
+hero: <i class="fab fa-superpowers"></i> Fusion for Kdb+
+---
+
+# ffikdb function reference
+
+The following functions are exposed in `ffi` namespace.
+
+<pre markdown="1" class="language-text">
+.ffi **FFI interface**
+
+Call Function
+    [bind](#ffibind)                    Create a projection with the function resolved to call with arguments.
+    [callFunction](#fficallfunction)    A simple one-off function call.
+Utility
+    [cvar](#fficvar)                    Read global variable from the library.
+    [extension](#ffiextension)          Return file extension of a shared object for a platform.
+    [os](#ffios)                        Return a letter denoting OS.
+    [ptrsize](#ptrsize)                 Return a size of `void*`.
+    [setErrno](#ffiseterrno)            Set `errno`.
+</pre>
+
+## Call Function
+
+### `.ffi.bind`
+
+_Creates a projection with the function resolved to call with arguments._
+
+Syntax: `bind[funcname;argtypes;returntype]`
+
+Where
+
+- `funcname`:
+  *  symbol: Name of function to look for.
+  *  symbol list: list of shared object and a function name in the library
+- `argtypes`: type characters of arguments.
+- `returntype`: type character of returned value
+
+Returns a q function, bound to the specifed C function for future calls. Useful for multiple calls to the C library.
+
+
+### `.ffi.callFunction`
+
+_A simple function call, intended for one-off calls._
+
+Syntax: `callFunction[returntype_and_func;args]`
+
+Where
+
+- `returntype_and_func`:
+ * symbol: Name of function
+ * tuple of (q type character of returned value; symbol function name or list of shared object name and function name)
+- `args`: List of arguments to be passed to the foreign function. This list must have (::) at the end.
+
+calls a function which has the given name with the arguments. 
+
+
+!!! warning "Function lookup"
+
+    `callFunction` performs function lookup on each call and has significant overhead. For hot-path functions use `bind`.
+
+## Utility
+
+### `.ffi.cvar`
+
+_Read global variable from the library._
+
+Syntax: `.ffi.cvar[rtype_and_var]`
+
+Where
+
+- rtype_and_var:
+  * symbol: Variable name
+  * tuple of (char; symbol): (type character of returned value; variable name or list of shared object name and variable name)
+
+In the second example it is assumed that `libsampleparser.so` is exposing a global variable `CHUNK_SIZE_THRESHOLD`, i.e. the result of `nm` command is like below:
+
+```bash
+
+$ nm -D l64/libsampleparser.so | grep CHUNK
+0000000000054a10 D CHUNK_SIZE_THRESHOLD
+
+```
+
+Then examples are:
+
+```q
+
+q).ffi.cvar`timezone
+-32400i
+q).ffi.cvar ("j"; `libsampleparser.so`CHUNK_SIZE_THRESHOLD)
+25000
+
+```
+
+### `.ffi.extension`
+
+_Return file extension of a shared object for a platform._
+
+```q
+
+q).ffi.extension[]
+`so
+q)` sv `libRmath, .ffi.extension[]
+`libRmath.so
+
+```
+
+### `.ffi.os`
+
+_Return a letter denoting OS._
+
+```q
+
+q).ffi.os[]
+"l"
+
+```
+
+### `.ffi.ptrsize`
+
+_Return a size of `void*`._
+
+```q
+
+q).ffi.ptrsize[]
+8i
+
+```
+
+### `.ffi.setErrno`
+
+_Get or set `errno`._
+
+Syntax:
+
+- `.ffi.setErrno[n]`: set `n` as `errno`.
+- `.ffi.setErrno[]`: get current `errno`.
+
+Where
+
+- `n` is a new `errno` value. This value must be int.
+
+```q
+
+q)// No such file or directory
+q).ffi.setErrno[]
+2i
+q)// No such process
+q).ffi.setErrno[3i]
+2i
+q).ffi.setErrno[]
+3i
+
+```
+
+## Passing data and getting results
+
+Throughout the library, characters are used to encode the types of data provided and expected as a result. These are based on the `c` column of [primitive data types](../basics/datatypes.md#primitive-datatypes) and the corresponding upper case for vectors of the same type. The `sz` column is useful to work out what type can hold enough data passing to/from C.
+
+The argument types are derived from data passed to the function (in case of `callFunction`) or explicitly specified (in case of `bind`). The number of character types provided must match the number of arguments expected by the C function.
+
+The return type is specified as a single character and can be `" "` (space), which means to discard the result (i.e. `void`). If not provided, defaults to `int`.
+
+char             | C type                                         | FFI type
+-----------------| -----------------------------------------------|------------------------------------
+b, c, x          | unsigned int8                                  | ffi_type_uint8
+h                | signed int16                                   | ffi_type_sint16
+i, m, d, u, v, t | signed int32                                   | ffi_type_sint32
+j, p, n          | signed int64                                   | ffi_type_sint64
+e                | float                                          | ffi_type_float
+f, z             | double                                         | ffi_type_double
+g, s             | uint8*                                         | ffi_type_pointer
+`" "` (space)    | void (only as return type)                     | ffi_type_void
+l                | size of pointer (size_t)                       | ffi_type_sint32 or ffi_type_sint64
+k                | callback function/closure (only argument type) | ffi_type_pointer
+uppercase letter | pointer to the same type                       | ffi_type_pointer
+
+It is possible to pass a q function to C code as a callback (see `qsort` example below). In that case argument type should be specified as `"k"`. The function must be presented as a mixed list `(func; argument_types; return_type)`, where `func` is a q function (type `100h`), `argument_types` is a char array with the types the function expects, and `return_type` is a char corresponding to the return type of the function. Note that, as callbacks potentially have unbounded life in C code, they are not deleted after the function completes.

--- a/examples/c_api.q
+++ b/examples/c_api.q
@@ -74,7 +74,7 @@ callback:{[fd]
 \
 .z.pc:{[client]
   -1 "Thanks God! He is gone after ", string[CALL_COUNT client], " knocks!!";
-  .ffi.callFunction[`sd1] (client; ::);
+  .ffi.callFunction[`sd0] (client; ::);
   exit 0;
  };
 


### PR DESCRIPTION
- Fixed C API example which called `sd1` at socket close. This should be `sd0`.
- Added documents