### PR TITLE
travis stopped supporting osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ jobs:
     os: linux
   - dist: bionic
     os: linux
-  - os: osx
   - os: windows
 os: linux
 dist: xenial


### PR DESCRIPTION
travis ci "Starting April 1st, 2025, OSx/macOS builds will no longer be supported due to the end-of-life (EOL) of VMWare support for macOS infrastructure. "