### PR TITLE
stop crash on returning null pointer, add docs on return types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,24 @@ jobs:
   include:
   - dist: xenial
     os: linux
+    - provider: releases
+      token: "$GITHUB_APIKEY"
+      file: "$FILE_NAME"
+      skip_cleanup: true
+      dpl_version: 1.10.16
+      on:
+        tags: true
   - dist: bionic
     os: linux
   - os: windows
+    deploy:
+    - provider: releases
+      token: "$GITHUB_APIKEY"
+      file: "$FILE_NAME"
+      skip_cleanup: true
+      dpl_version: 2.0.3.beta.4
+      on:
+        tags: true
 os: linux
 dist: xenial
 language: c
@@ -99,13 +114,3 @@ script:
     else
       tar -czf ${FILE_NAME} build/${FILE_ROOT};
     fi
-
-deploy:
-  provider: releases
-  token: ${GITHUB_APIKEY}
-  file: ${FILE_NAME}
-  skip_cleanup: true
-  dpl_version: 2.0.3.beta.4
-  on:
-    tags: true
-    condition: $TRAVIS_OS_NAME == "windows" || $TRAVIS_OS_NAME == "osx" || ($TRAVIS_OS_NAME == "linux" && $TRAVIS_DIST == "xenial")

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ jobs:
   include:
   - dist: xenial
     os: linux
+    deploy:
     - provider: releases
       token: "$GITHUB_APIKEY"
       file: "$FILE_NAME"

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -152,9 +152,12 @@ q).ffi.setErrno[]
 
 ## Passing data and getting results
 
-Throughout the library, characters are used to encode the types of data provided and expected as a result. These are based on the `c` column of [primitive data types](../basics/datatypes.md#primitive-datatypes) and the corresponding upper case for vectors of the same type. The `sz` column is useful to work out what type can hold enough data passing to/from C.
+Throughout the library, characters are used to encode the types of data provided and expected as a result. 
+These are based on the `c` column of [primitive data types](../basics/datatypes.md#primitive-datatypes) and the corresponding upper case for vectors of the same type. 
+The `sz` column is useful to work out what type can hold enough data passing to/from C.
 
-The argument types are derived from data passed to the function (in case of `callFunction`) or explicitly specified (in case of `bind`). The number of character types provided must match the number of arguments expected by the C function.
+The argument types are derived from data passed to the function (in case of `callFunction`) or explicitly specified (in case of `bind`). 
+The number of character types provided must match the number of arguments expected by the C function.
 
 The return type is specified as a single character and can be `" "` (space), which means to discard the result (i.e. `void`). If not provided, defaults to `int`.
 
@@ -172,4 +175,12 @@ l                | size of pointer (size_t)                       | ffi_type_sin
 k                | callback function/closure (only argument type) | ffi_type_pointer
 uppercase letter | pointer to the same type                       | ffi_type_pointer
 
-It is possible to pass a q function to C code as a callback (see `qsort` example below). In that case argument type should be specified as `"k"`. The function must be presented as a mixed list `(func; argument_types; return_type)`, where `func` is a q function (type `100h`), `argument_types` is a char array with the types the function expects, and `return_type` is a char corresponding to the return type of the function. Note that, as callbacks potentially have unbounded life in C code, they are not deleted after the function completes.
+It is possible to pass a q function to C code as a callback (see `qsort` example). 
+In that case argument type should be specified as `"k"`. 
+The function must be presented as a mixed list `(func; argument_types; return_type)`, where `func` is a q function (type `100h`), `argument_types` is a char array with the types the function expects, and `return_type` is a char corresponding to the return type of the function. 
+Note that, as callbacks potentially have unbounded life in C code, they are not deleted after the function completes.
+
+When interfacing with a C function that returns a pointer to a value, using a return type set to an uppercase letter (for example J corresponding to a pointer to a signed int64) the interface
+will not know if its pointing to one value or many. 
+Therefore the return type will be a single atom value of the value being pointed to (not a vector of values, nor a vector of a single value) of values, nor a vector of a single value).
+The exception is when the return type is `char*`, where the interface will create a character vector by looking for the null terminator character in the C string.

--- a/src/ffi.c
+++ b/src/ffi.c
@@ -261,7 +261,7 @@ static K kvalue(I targettype, void *ret) {
   }
   else if(targettype == KC) {
     // string
-    S rs=*(S*)ret;
+    S rs=(ret&&(*(S)ret))?*(S*)ret:"";
     r= ktn(KC, strlen(rs));
     memmove(kG(r), rs, r->n);
     return r;
@@ -286,14 +286,17 @@ static K kvalue(I targettype, void *ret) {
   r= ka(targettype);
   switch(targettype) {
     case -KB:
-    case -KC:
     case -KG:
-      // bool, char or byte
-      r->g= *(G *)ret;
+      // bool or byte
+      r->g= ret?*(G *)ret:0;
+      return r;
+    case -KC:
+      // char
+      r->g= ret?*(G *)ret:32; // 32 is a space (null char)
       return r;
     case -KH:
       // short
-      r->h= *(H *)ret;
+      r->h= ret?*(H *)ret:nh;
       return r;
     case -KM:
     case -KD:
@@ -302,26 +305,27 @@ static K kvalue(I targettype, void *ret) {
     case -KT:
     case -KI:
       // month, date, minute, second, time or int
-      r->i= *(I *)ret;
+      r->i= ret?*(I *)ret:ni;
       return r;
     case -KJ:
     case -KP:
     case -KN:
       // long, timestamp or timespan
-      r->j= *(J *)ret;
+      r->j= ret?*(J *)ret:nj;
       return r;
     case -KE:
       // real
-      r->e= *(E *)ret;
+      //r->e= *(E *)ret;
+      r->e= ret?*(E *)ret:nf;
       return r;
     case -KZ:
     case -KF:
       // datetime or float
-      r->f= *(F *)ret;
+      r->f= ret?*(F *)ret:nf;
       return r;
     case -KS:
       // symbol
-      r->s= ss(*(S *)ret);
+      r->s= ret?ss(*(S *)ret):ss("");
       return r;
     default:
       // Unsupported type


### PR DESCRIPTION
the following would have caused a crash
e.g.
```
long* null_long(int n) {
    return NULL;
}
```
```
null_long:.ffi.bind[`libadd.so`null_long;"i";"J"];
0N!r:null_long(3i;::);
```